### PR TITLE
Fix the mismatched senses bug

### DIFF
--- a/src/SenseDisplay.js
+++ b/src/SenseDisplay.js
@@ -170,6 +170,7 @@ class SenseDisplay extends Component {
       nextProps.idGlossPos.token_id !== undefined
     ) {
       this.setState({
+        selectedSenses: [],
         isWrongPosAlertOpen: false,
         disabledSenseSelection: false
       });
@@ -395,7 +396,7 @@ class SenseDisplay extends Component {
                   <thead>
                     <tr>
                       <th>Senses</th>
-                      <th>Examples</th>                      
+                      <th>Examples</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -448,7 +449,7 @@ class SenseDisplay extends Component {
                                 <ButtonNext>{">"}</ButtonNext>
                                 <ButtonLast>{">>"}</ButtonLast>
                               </CarouselProvider>
-                            </td>                            
+                            </td>
                           </tr>
                         );
                       } else
@@ -457,7 +458,7 @@ class SenseDisplay extends Component {
                             No senses found for the current token and its part
                             of speech. This may be the case if the Part of Speech
                             listed in the transcript is incorrect. Click "Wrong Part
-                            of Speech" to correct if so. 
+                            of Speech" to correct if so.
                           </label>
                         );
                     })}


### PR DESCRIPTION
Clears the selected senses when a user selects a new token, which will stop the user from saving senses for the previously selected token. 
Fixes #9